### PR TITLE
adding IPv6 code to close workers when future queue is empty

### DIFF
--- a/examples/producer.py
+++ b/examples/producer.py
@@ -5,10 +5,10 @@ import faktory
 with faktory.connection() as client:
     while True:
         client.queue("add", args=(1, 2), queue="default")
-        time.sleep(1)
+        time.sleep(.1)
 
-        client.queue("subtract", args=(10, 5), queue="default")
-        time.sleep(1)
+        #client.queue("subtract", args=(10, 5), queue="default")
+        #time.sleep(1)
 
-        client.queue("multiply", args=(8, 8), queue="default")
-        time.sleep(1)
+        #client.queue("multiply", args=(8, 8), queue="default")
+        #time.sleep(1)

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -27,10 +27,10 @@ def multiply_numbers(x, y):
 
 
 if __name__ == "__main__":
-    w = Worker(faktory="tcp://localhost:7419", queues=["default"], concurrency=1)
+    w = Worker(queues=["default"], concurrency=10)
     w.register("add", add_numbers)
-    w.register("subtract", subtract_numbers)
-    w.register("multiply", multiply_numbers)
+    #w.register("subtract", subtract_numbers)
+    #w.register("multiply", multiply_numbers)
     w.run()  # runs until control-c or worker shutdown from Faktory web UI
 
 # check examples/producer.py for how to submit tasks to be run by faktory

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -68,7 +68,14 @@ class Connection:
         self.log.info("Connecting to {}:{}".format(self.host, self.port))
         self.is_connecting = True
 
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # handle IPv4 or IPv6 hosts, get addr info returns a list of tuples of tuples
+        # this always uses the first one
+        faktory_ip_addresses = socket.getaddrinfo(self.host, None)
+        faktory_ip_address = faktory_ip_addresses[0][4][0]
+        faktory_ip_address_faimly = faktory_ip_addresses[0][0]
+
+        self.socket = socket.socket(faktory_ip_address_faimly, socket.SOCK_STREAM)
+
         if self.use_tls:
             self.log.debug("Using TLS")
             self.socket = ssl.wrap_socket(self.socket)
@@ -76,7 +83,7 @@ class Connection:
         self.socket.setblocking(0)
         self.socket.settimeout(self.timeout)
         try:
-            self.socket.connect((self.host, self.port))
+            self.socket.connect((faktory_ip_address, self.port))
         except ssl.SSLError:
             raise
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -179,12 +179,19 @@ class Worker:
                 self.disconnect(force=True, wait=15)
                 break
 
+            # added a check for can_disconnect, checks if futures queue is empty
+            # if it is we exit the while loop
+            if self.can_disconnect:
+                break
+
         if self.faktory.is_connected:
             self.log.warning("Forcing worker processes to shutdown...")
             self.disconnect(force=True)
 
         self.executor.shutdown(wait=False)
-        sys.exit(1)
+        # changed to exit(0) to keep Titus happy (really this should be an expected exit because queue is empty)
+        # only other option seems to be because of a keyboard interrupt
+        sys.exit(0)
 
     def disconnect(self, force=False, wait=30):
         """


### PR DESCRIPTION
Added code to allow connecting to IPv6 (and IPv4) servers.  Also, added code to quit workers when futures queue is empty to support a use case where we start up many workers in many containers and then want them all go quit after the work is done to save resources (only runs once a day).  We could do this with batches, but the library doesn't support them.